### PR TITLE
added support for enabling stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,64 @@ plaintext data only exists in memory.
 ## installation
 Clone this repo and `cd` to the folder and run `go install`
 
+## Setup
+### Solana Config
+Setup config file used by `Solana` CLI tools to look something as follows
+```
+└─ $ ▶ solana config get
+Config File: /home/username/.config/solana/cli/config.yml
+RPC URL: http://localhost:8899 
+WebSocket URL: ws://localhost:8900/ (computed)
+Keypair Path: stdin:/home/username/.config/solana/id 
+Commitment: confirmed 
+```
+Note that the `Keypair Path` has `stdin:` prefix, which triggers the behavior
+by Solana CLI tools to accept keypair from STDIN. The actual path is ignored
+by the Solana CLI tools, however, this CLI makes use of that path to store
+the KMS encrypted data.
+
+Make sure that the file `/home/username/.config/solana/id` does not exist when
+creating a new key.
+
+### Setup KMS
+Please follow Google KMS instructions to create a KMS keyring and a key. In addition,
+you will also need a service account with KMS encrypter/decrypter role. Setup following
+environment variables:
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.config/service-accounts/service-account.json"
+export LOCATION=<kms location>
+export KEYRING=<keyring name>
+export KEY=<key name>
+export PROJECT=<project id>
+```
+
+## Usage
+### Create a new key
+Run `solana-kms key new` to generate a new keypair. It will write the encrypted keydata
+to the filepath set previously (`/home/username/.config/solana/id`) and also write
+encrypted seed for it.
+
+### Use the key
+The key can now be used with other Solana CLI tools by piping via STDIN.
+```
+└─ $ ▶ solana-kms key pubkey 
+B9g4B79PHmyCcRQnuAxmzXK1PriVGqmxT7wo4DT7QRUP
+```
+```
+└─ $ ▶ solana-kms key decrypt | solana-keygen pubkey
+B9g4B79PHmyCcRQnuAxmzXK1PriVGqmxT7wo4DT7QRUP
+```
+Similarly, use against an endpoint to airdrop sols and check balance
+```
+└─ $ ▶ solana-kms key decrypt | solana airdrop 100 
+Requesting airdrop of 100 SOL
+
+Signature: 5Z8s3BUStxym3NyXT7zE2fxpgVi6VnL66F78ZyMkr6DdQ1v65ZgsW74xT2oJrDuv1kvGwfp8tjYiSvNdEDfSMgxm
+
+100 SOL
+```
+
+```
+└─ $ ▶ solana-kms key decrypt | solana balance
+100 SOL
+```

--- a/pkg/run/accountInfo.go
+++ b/pkg/run/accountInfo.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/kubetrail/solana-kms/pkg/flags"
 	"github.com/portto/solana-go-sdk/client"
-	"github.com/portto/solana-go-sdk/rpc"
 	"github.com/portto/solana-go-sdk/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,7 +33,7 @@ func AccountInfo(cmd *cobra.Command, _ []string) error {
 	var endpoint string
 	var configValues *config
 
-	if len(pubKey) == 0 || len(url) == 0 {
+	if (len(pubKey) == 0 && len(keyFile) == 0) || len(url) == 0 {
 		var err error
 		if len(configFile) == 0 {
 			configFile, err = getDefaultConfigFilename()
@@ -52,20 +50,7 @@ func AccountInfo(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	switch strings.ToLower(url) {
-	case "mainnet":
-		endpoint = rpc.MainnetRPCEndpoint
-	case "devnet":
-		endpoint = rpc.DevnetRPCEndpoint
-	case "testnet":
-		endpoint = rpc.TestnetRPCEndpoint
-	case "localnet", "localhost":
-		endpoint = rpc.LocalnetRPCEndpoint
-	case "":
-		endpoint = configValues.JsonRpcUrl
-	default:
-		endpoint = url
-	}
+	endpoint = getEndpointFromUrlOrMoniker(url, configValues)
 
 	if len(pubKey) == 0 {
 		if err := setAppCredsEnvVar(persistentFlags.ApplicationCredentials); err != nil {
@@ -74,8 +59,14 @@ func AccountInfo(cmd *cobra.Command, _ []string) error {
 		}
 
 		if len(keyFile) == 0 {
+			if configValues == nil || len(configValues.KeypairPath) == 0 {
+				err := fmt.Errorf("could not find a valid keypair path from config file")
+				return err
+			}
 			keyFile = configValues.KeypairPath
 		}
+
+		keyFile = removeSchemeFromPath(keyFile)
 
 		kmsClient, err := kms.NewKeyManagementClient(ctx)
 		if err != nil {

--- a/pkg/run/util.go
+++ b/pkg/run/util.go
@@ -5,6 +5,9 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/portto/solana-go-sdk/rpc"
 
 	"github.com/kubetrail/solana-kms/pkg/flags"
 	"github.com/spf13/cobra"
@@ -104,4 +107,25 @@ func setAppCredsEnvVar(applicationCredentials string) error {
 	}
 
 	return nil
+}
+
+func getEndpointFromUrlOrMoniker(url string, configValues *config) string {
+	switch strings.ToLower(url) {
+	case "mainnet":
+		return rpc.MainnetRPCEndpoint
+	case "devnet":
+		return rpc.DevnetRPCEndpoint
+	case "testnet":
+		return rpc.TestnetRPCEndpoint
+	case "localnet", "localhost":
+		return rpc.LocalnetRPCEndpoint
+	case "":
+		return configValues.JsonRpcUrl
+	default:
+		return url
+	}
+}
+
+func removeSchemeFromPath(input string) string {
+	return strings.TrimLeft(input, "stdin:")
 }


### PR DESCRIPTION
This pr fixes a few bugs in the code and adds support for `stdin` scheme in solana config, which allows usage of this cli in conjunction with other solana tools via stdin piping. pl. see updated readme.
Signed-off-by: Saurabh Deoras <sdeoras@gmail.com>