### PR TITLE
recreate seed file for key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ All actions requiring use of private key will go through KMS roundtrip
 to decrypt the private key at runtime ensuring that the private key
 plaintext data only exists in memory.
 
+## Installation
+Clone this repo and `cd` to the folder and run `go install`. This assumes you
+have Go (Golang) toolchain installed. Also install Solana CLI tools.
 
-## installation
-Clone this repo and `cd` to the folder and run `go install`
+* https://go.dev/dl/
+* https://docs.solana.com/cli/install-solana-cli-tools
 
 ## Setup
 ### Solana Config
@@ -49,8 +52,14 @@ Run `solana-kms key new` to generate a new keypair. It will write the encrypted 
 to the filepath set previously (`/home/username/.config/solana/id`) and also write
 encrypted seed for it.
 
+```
+└─ $ ▶ solana-kms key new
+```
+
 ### Use the key
-The key can now be used with other Solana CLI tools by piping via STDIN.
+The key can now be used with other Solana CLI tools by piping via STDIN. You can verify
+that is working by fetching public key address from `solana-kms` directly or via
+`solana-keygen` CLI as shown below:
 ```
 └─ $ ▶ solana-kms key pubkey 
 B9g4B79PHmyCcRQnuAxmzXK1PriVGqmxT7wo4DT7QRUP
@@ -59,7 +68,8 @@ B9g4B79PHmyCcRQnuAxmzXK1PriVGqmxT7wo4DT7QRUP
 └─ $ ▶ solana-kms key decrypt | solana-keygen pubkey
 B9g4B79PHmyCcRQnuAxmzXK1PriVGqmxT7wo4DT7QRUP
 ```
-Similarly, use against an endpoint to airdrop sols and check balance
+Similarly, this setup can be used against all Solana CLI tools that support
+keypair input via STDIN
 ```
 └─ $ ▶ solana-kms key decrypt | solana airdrop 100 
 Requesting airdrop of 100 SOL
@@ -73,3 +83,17 @@ Signature: 5Z8s3BUStxym3NyXT7zE2fxpgVi6VnL66F78ZyMkr6DdQ1v65ZgsW74xT2oJrDuv1kvGw
 └─ $ ▶ solana-kms key decrypt | solana balance
 100 SOL
 ```
+
+## Key Rotation
+It is possible to regenerate the keypair from the seed. The newly created ecrypted
+file will differ from the original, however, they both would map to the same
+plaintext bytes.
+```
+└─ $ ▶ solana-kms key new --keyfile=/path/to/new/id --seedfile=/path/to/old/id.seed
+```
+This will generate two new files `/path/to/new/id` and `/path/to/new/id.seed`. At this
+point the previous keypair and seed files can be deleted and any associated KMS
+key version that was used for encryption of those old keypair files,
+but is no longer in use, can also be disabled. In other words, we are not rotating
+the Solana keys, the roation implies to the encrypted content using different
+versions of the KMS keys.

--- a/pkg/run/keyNew.go
+++ b/pkg/run/keyNew.go
@@ -188,9 +188,7 @@ func KeyNew(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if len(seedFile) == 0 {
-		seedFile = fmt.Sprintf("%s.%s", keyFile, "seed")
-	}
+	seedFile = fmt.Sprintf("%s.%s", keyFile, "seed")
 	if err := os.WriteFile(seedFile, encryptResponseSeed.Ciphertext, 0400); err != nil {
 		err := fmt.Errorf("could not write encrypted private key seed to outfile: %w", err)
 		return err


### PR DESCRIPTION
This pr ensures that new seed is generated during key rotation from previous seed. Also updated readme.
Signed-off-by: Saurabh Deoras <sdeoras@gmail.com>